### PR TITLE
ロール自動付与の調整

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,9 +162,11 @@ client.on("guildMemberAdd", async (member) => {
     member.roles.add("1454099602641780737");
   }
 
-  // 第1期生ロールを付与
+  // 年に応じたロールを付与
   if (date.getFullYear() == 2025) {
     member.roles.add("1454661774576980090");
+  } else if (date.getFullYear() == 2026) {
+    member.roles.add("1455864840630308925");
   }
 
   await updateMemberCount(client);


### PR DESCRIPTION
# features
## 1. ロールの自動付与
- BOTを検知し、BOTロールと、学生ロールを自動付与
- 2026年入学生徒のための第2期生ロールの自動付与

## 追記
なお、第1期生から第2期生ロールの自動付与については、特に操作を行う必要はなく、ユーザがサーバに入った時点で時刻を取得し、その年で判別しています。