### PR TITLE
PR時のスペルチェッカーを追加

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,18 @@
+name: Spell Check
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on: [pull_request]
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos and Reviewdog
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: reviewdog/action-typos@v1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,7 @@
+[files]
+extend-exclude = [
+    
+]
+
+[default]
+binary = false


### PR DESCRIPTION
## 概要
PRにスペルチェッカーを導入しました。
自動でPR上でのコミットのタイプミスを検出します。

## Review依頼
- 除外ファイル(=typoをチェックしないファイル)の有無