### PR TITLE
Fix: 学生数のカウントから未認証の人を除外

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,10 +194,12 @@ client.on("guildMemberUpdate", async (oldMember, newMember) => {
     `   -> hasStudentRole: ${oldMember.roles.cache.has("1454446371221536788")}`,
   );
 
-  //　学生ロールの付与を検知して学生数カウントを更新
+  //　学生ロールの付与、剥奪を検知して学生数カウントを更新
   if (
-    !oldMember.roles.cache.has("1454446371221536788") &&
-    newMember.roles.cache.has("1454446371221536788")
+    (!oldMember.roles.cache.has("1454446371221536788") &&
+      newMember.roles.cache.has("1454446371221536788")) ||
+    (oldMember.roles.cache.has("1454446371221536788") &&
+      !newMember.roles.cache.has("1454446371221536788"))
   ) {
     await updateMemberCount(client);
   }

--- a/src/jobs/updateMemberCount.ts
+++ b/src/jobs/updateMemberCount.ts
@@ -7,10 +7,10 @@ const GUILD_ID = "1452263053180534806";
 let membersFetched = false;
 
 export async function updateMemberCount(client: Client) {
-  console.log("Starting member count job...");
+  console.log("[INFO]  Starting member count job...");
 
   try {
-    console.log("Updating member count...");
+    console.log("[INFO]  Updating member count...");
 
     const guild = client.guilds.cache.get(GUILD_ID);
     if (!guild) {
@@ -38,18 +38,18 @@ export async function updateMemberCount(client: Client) {
     const memberCount = studentRole.members.size;
 
     await channel.setName(`学生数: ${memberCount}`);
-    console.log(`Updated member count in ${channel.name}`);
+    console.log(`[INFO]  Updated member count in ${channel.name}`);
   } catch (error) {
-    console.error(`Error updating member count: ${error}`);
+    console.error(`[ERROR] Updating member count: ${error}`);
   }
 }
 
 export async function firstJob(client: Client) {
-  console.log("[INFO] Starting first job...");
+  console.log("[INFO]  Starting first job...");
 
   const guild = await client.guilds.fetch(GUILD_ID);
   await guild.members.fetch();
   membersFetched = true;
 
-  console.log("First job completed");
+  console.log("[INFO]  First job completed");
 }


### PR DESCRIPTION
# Fix
## 1. 学生数のカウントから未認証の人を除外
今まで未認証であった人もカウントされていたため、そのカウントを除外し、学生ロールの人数を使用するようにしました。

（このため、BOTから学生ロールを削除しています）