### PR TITLE
hotfix: Axiosのサプライチェーン攻撃に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "dependencies": {
     "discord.js": "^14.25.1",
-    "dotenv": "^17.2.3"
-  }
+    "dotenv": "^17.2.3",
+    "axios": "1.14.0"
+  },
+  "overrides" : {
+    "axios": "1.14.0"
 }


### PR DESCRIPTION
Axiosのパッケージは現状使用していないが、今後の使用も考えられるためパッケージバージョンを安全なものに固定

詳細: [【緊急】axiosがサプライチェーン攻撃を受けました 今すぐ確認・対処してください（2026/03/31）](https://qiita.com/kawabe0201/items/b51cd76daa2fec5029f1)