### PR TITLE
fix: チケット認可チェック、VC権限昇格修正、レート制限、JSON.parse安全化

### DIFF
--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -128,8 +128,8 @@ export default {
             const actionRow = new ActionRowBuilder<ButtonBuilder>();
             actionRow.addComponents(button);
 
-            await interaction.followUp({ embeds: [embed], components: [actionRow] });
             ticketCooldowns.set(userId, Date.now());
+            await interaction.followUp({ embeds: [embed], components: [actionRow] });
         } catch (error) {
             console.error(error);
             const embed = new EmbedBuilder()

--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -1,13 +1,18 @@
-import { EmbedBuilder, MessageFlags, ApplicationCommandOptionType, ChatInputCommandInteraction, ChannelType, Colors, ButtonBuilder, ButtonStyle } from "discord.js";
+import { EmbedBuilder, MessageFlags, ApplicationCommandOptionType, ChatInputCommandInteraction, ChannelType, Colors, ButtonBuilder, ButtonStyle, PermissionFlagsBits } from "discord.js";
 import { createButton } from "../libs/button";
 import { Command } from "../types/command";
 import botConfig from "../../bot.config";
 import { ActionRowBuilder } from "discord.js";
 
+// Rate limit: userId -> last ticket creation timestamp
+const ticketCooldowns: Map<string, number> = new Map();
+const TICKET_COOLDOWN_MS = 60_000; // 60 seconds
+
 export default {
     data: {
         name: "ticket",
         description: "チケットボードを作成します",
+        default_member_permissions: PermissionFlagsBits.ManageChannels.toString(),
         defer: true,
 
         options: [
@@ -55,9 +60,30 @@ export default {
             return;
         }
 
-        // 認証関連をここに実装。実行できる人は限られる想定
-        const roles = interaction.member?.roles;
-        // console.log(roles);
+        // 権限チェック: ManageChannels 権限が必要
+        const memberPermissions = interaction.memberPermissions;
+        if (!memberPermissions?.has(PermissionFlagsBits.ManageChannels)) {
+            const embed = new EmbedBuilder()
+                .setTitle("エラー")
+                .setDescription("このコマンドを実行するにはチャンネル管理権限が必要です。")
+                .setColor(Colors.Red);
+            await interaction.followUp({ embeds: [embed] });
+            return;
+        }
+
+        // レートリミット: 60秒に1回まで
+        const userId = interaction.user.id;
+        const now = Date.now();
+        const lastUsed = ticketCooldowns.get(userId);
+        if (lastUsed && now - lastUsed < TICKET_COOLDOWN_MS) {
+            const remaining = Math.ceil((TICKET_COOLDOWN_MS - (now - lastUsed)) / 1000);
+            const embed = new EmbedBuilder()
+                .setTitle("エラー")
+                .setDescription(`チケットボードの作成は60秒に1回までです。あと${remaining}秒お待ちください。`)
+                .setColor(Colors.Red);
+            await interaction.followUp({ embeds: [embed] });
+            return;
+        }
 
 
         try {
@@ -103,6 +129,7 @@ export default {
             actionRow.addComponents(button);
 
             await interaction.followUp({ embeds: [embed], components: [actionRow] });
+            ticketCooldowns.set(userId, Date.now());
         } catch (error) {
             console.error(error);
             const embed = new EmbedBuilder()

--- a/src/handlers/events/vc/join.ts
+++ b/src/handlers/events/vc/join.ts
@@ -26,7 +26,6 @@ const handleVcJoin = (async (oldState: VoiceState, newState: VoiceState) => {
                         PermissionFlagsBits.Connect,
                         PermissionFlagsBits.Speak,
                         PermissionFlagsBits.ViewChannel,
-                        PermissionFlagsBits.ManageChannels,
                     ],
                 },
             ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,18 @@ client.on("interactionCreate", async (interaction: Interaction<CacheType>) => {
     // ボタン
     if (interaction.isButton()) {
       const { customId } = interaction;
-      const command: ButtonCommand = JSON.parse(customId);
+      let command: ButtonCommand;
+      try {
+        const parsed = JSON.parse(customId);
+        if (typeof parsed !== "object" || parsed === null || typeof parsed.action !== "string") {
+          console.error(`Invalid button customId format: ${customId}`);
+          return;
+        }
+        command = parsed as ButtonCommand;
+      } catch {
+        console.error(`Failed to parse button customId: ${customId}`);
+        return;
+      }
       const actionName = command.action;
       const action: Action<ButtonInteraction> | undefined =
         actions.button[actionName];
@@ -133,7 +144,18 @@ client.on("interactionCreate", async (interaction: Interaction<CacheType>) => {
     // モーダル
     if (interaction.isModalSubmit()) {
       const { customId } = interaction;
-      const command: ModalCommand = JSON.parse(customId);
+      let command: ModalCommand;
+      try {
+        const parsed = JSON.parse(customId);
+        if (typeof parsed !== "object" || parsed === null || typeof parsed.action !== "string") {
+          console.error(`Invalid modal customId format: ${customId}`);
+          return;
+        }
+        command = parsed as ModalCommand;
+      } catch {
+        console.error(`Failed to parse modal customId: ${customId}`);
+        return;
+      }
       const actionName = command.action;
       const action: Action<ModalSubmitInteraction> | undefined =
         actions.modal[actionName];

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,11 +117,13 @@ client.on("interactionCreate", async (interaction: Interaction<CacheType>) => {
         const parsed = JSON.parse(customId);
         if (typeof parsed !== "object" || parsed === null || typeof parsed.action !== "string") {
           console.error(`Invalid button customId format: ${customId}`);
+          await interaction.deferUpdate();
           return;
         }
         command = parsed as ButtonCommand;
       } catch {
         console.error(`Failed to parse button customId: ${customId}`);
+        await interaction.deferUpdate();
         return;
       }
       const actionName = command.action;
@@ -149,11 +151,13 @@ client.on("interactionCreate", async (interaction: Interaction<CacheType>) => {
         const parsed = JSON.parse(customId);
         if (typeof parsed !== "object" || parsed === null || typeof parsed.action !== "string") {
           console.error(`Invalid modal customId format: ${customId}`);
+          await interaction.reply({ content: "invalid request", ephemeral: true });
           return;
         }
         command = parsed as ModalCommand;
       } catch {
         console.error(`Failed to parse modal customId: ${customId}`);
+        await interaction.reply({ content: "invalid request", ephemeral: true });
         return;
       }
       const actionName = command.action;


### PR DESCRIPTION
## 概要
- `/ticket` コマンドに `ManageChannels` 権限チェックを追加
- チケット作成に60秒のクールダウンを追加（スパム防止）
- VC作成者への `ManageChannels` 権限付与を削除（権限昇格防止）
- ボタン/モーダルの `customId` の `JSON.parse` を try/catch + 形式検証で安全化
- パース失敗時に interaction を ACK するよう修正（レビュー指摘対応）
- クールダウンを `followUp` の前にセットするよう修正（レビュー指摘対応）