### PR TITLE
一時VC削除時の Missing Access とWebhook URL未設定時の例外を修正

### DIFF
--- a/src/handlers/events/vc/join.ts
+++ b/src/handlers/events/vc/join.ts
@@ -7,34 +7,54 @@ const handleVcJoin = (async (oldState: VoiceState, newState: VoiceState) => {
     const channelId = newState.channel.id;
     if (channelId !== botConfig.voice.customChannelId) return;
 
+    const memberId = newState.member?.id ?? newState.member?.user.id;
+    if (!memberId) return;
+
     try {
+        const permissionOverwrites = [
+            {
+                id: newState.guild.roles.everyone.id,
+                deny: [PermissionFlagsBits.ViewChannel],
+            },
+            {
+                id: botConfig.role.memberId,
+                allow: [
+                    PermissionFlagsBits.ViewChannel,
+                    PermissionFlagsBits.Connect,
+                ],
+            },
+            {
+                id: memberId,
+                allow: [
+                    PermissionFlagsBits.Connect,
+                    PermissionFlagsBits.Speak,
+                    PermissionFlagsBits.ViewChannel,
+                ],
+            },
+        ];
+
+        const botMember = newState.guild.members.me;
+        if (botMember) {
+            permissionOverwrites.push({
+                id: botMember.id,
+                allow: [
+                    PermissionFlagsBits.ViewChannel,
+                    PermissionFlagsBits.Connect,
+                    PermissionFlagsBits.Speak,
+                    PermissionFlagsBits.ManageChannels,
+                    PermissionFlagsBits.MoveMembers,
+                ],
+            });
+        }
+
         const channel = await newState.guild.channels.create({
             name: `🔊｜${newState.member?.user.username}の部屋`,
             type: ChannelType.GuildVoice,
             parent: newState.channel.parentId ?? undefined,
-            permissionOverwrites: [
-                {
-                    id: botConfig.role.memberId,
-                    allow: [
-                        PermissionFlagsBits.ViewChannel, 
-                        PermissionFlagsBits.Connect
-                    ],
-                },
-                {
-                    id: newState.member?.id || newState.member?.user.id || "",
-                    allow: [
-                        PermissionFlagsBits.Connect,
-                        PermissionFlagsBits.Speak,
-                        PermissionFlagsBits.ViewChannel,
-                    ],
-                },
-            ],
+            permissionOverwrites,
         });
 
         await newState.member?.voice.setChannel(channel);
-        await channel.permissionOverwrites.create(newState.guild.roles.everyone, {
-            ViewChannel: false,
-        });
     } catch (error) {
         console.error("vc-join: チャンネル作成に失敗しました:", error);
     }

--- a/src/handlers/events/vc/leave.ts
+++ b/src/handlers/events/vc/leave.ts
@@ -1,4 +1,4 @@
-import { VoiceState, ChannelType } from "discord.js";
+import { VoiceState } from "discord.js";
 import botConfig from "../../../../bot.config";
 
 const handleVcLeave = (async (oldState: VoiceState, newState: VoiceState) => {
@@ -15,15 +15,23 @@ const handleVcLeave = (async (oldState: VoiceState, newState: VoiceState) => {
             await channel.delete();
         } catch (error) {
             console.error("vc-leave: チャンネル削除に失敗しました:", error);
-            await fetch(process.env.WEBHOOK_URL || "", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    content: `vc-leave: チャンネル削除に失敗しました: ${error}`,
-                }),
-            });
+
+            const webhookUrl = process.env.WEBHOOK_URL?.trim();
+            if (!webhookUrl) return;
+
+            try {
+                await fetch(webhookUrl, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        content: `vc-leave: チャンネル削除に失敗しました: ${String(error)}`,
+                    }),
+                });
+            } catch (webhookError) {
+                console.error("vc-leave: Webhook送信に失敗しました:", webhookError);
+            }
         }
     }
 });


### PR DESCRIPTION
## 概要

一時ボイスチャンネルの削除に失敗したとき、追加で `fetch("")` が実行されて `TypeError: Failed to parse URL from` が出る問題を修正しました。
あわせて、作成した一時VCをBot自身が閲覧・管理できるように権限上書きを明示し、削除時の `DiscordAPIError[50001]: Missing Access` が起きにくいようにしています。

## 原因

- 一時VC作成後に `@everyone` の `ViewChannel` を後から拒否しており、環境によってはBotが対象チャンネルへアクセスできない状態になる可能性がありました。
- チャンネル削除失敗時の通知で `process.env.WEBHOOK_URL || ""` をそのまま `fetch` に渡していたため、Webhook URL 未設定時に空文字列URLとして扱われ、削除失敗ログの後に別の例外が発生していました。

## 変更内容

- 一時VC作成時点で `@everyone` の閲覧拒否、メンバーロール・作成者・Bot自身の権限をまとめて設定するように変更しました。
- Bot自身に `ViewChannel` と `ManageChannels` など、作成後の移動・削除に必要な権限を明示しました。
- `WEBHOOK_URL` が未設定または空白の場合は通知送信をスキップするようにしました。
- Webhook送信自体に失敗した場合も、別途ログを出して処理が落ちないようにしました。

## 確認

- `npm run build` が成功することを確認しました。
- なお、このリポジトリでは既存の `package.json` と `package-lock.json` が同期していないため、`npm ci` は今回の変更前から失敗します。
