### PR TITLE
起動時とイベント処理の未処理例外を防ぐ

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   ButtonInteraction,
   Interaction,
   CacheType,
+  GuildMember,
 } from "discord.js";
 import { Command, ModalCommand, ButtonCommand } from "./types/command";
 import { Action, Actions } from "./types/action";
@@ -48,35 +49,56 @@ const client = new Client({
 
 let reactionRoleMessage: string = "";
 
+async function runSafely(label: string, task: () => Promise<void>) {
+  try {
+    await task();
+  } catch (error) {
+    console.error(`[ERROR] ${label}:`, error);
+  }
+}
+
+async function addRoleSafely(member: GuildMember, roleId: string, label: string) {
+  try {
+    await member.roles.add(roleId);
+  } catch (error) {
+    console.error(`[ERROR] Failed to add ${label} role (${roleId}):`, error);
+  }
+}
+
 client.once("clientReady", async () => {
   console.log(`Logged in as ${client.user?.tag}`);
 
-  // Registering commands
-  const data: Record<string, any>[] = new Array();
+  await runSafely("Registering commands", async () => {
+    const data: Record<string, any>[] = new Array();
 
-  for (const commandName in commands) {
-    console.warn(`  Registering command: ${commandName}`);
-    data.push(commands[commandName].data);
-  }
+    for (const commandName in commands) {
+      console.warn(`  Registering command: ${commandName}`);
+      data.push(commands[commandName].data);
+    }
 
-  await client.application?.commands.set(data as any);
+    await client.application?.commands.set(data as any);
 
-  console.log("Commands registered successfully!");
+    console.log("Commands registered successfully!");
+  });
   console.log("");
   console.log("Bot is ready!");
   console.log("");
 
-  await firstJob(client);
-  await updateMemberCount(client);
+  await runSafely("Initial member fetch", () => firstJob(client));
+  await runSafely("Initial member count update", () => updateMemberCount(client));
 
-  const result = await checkReactionRoleMessage(client);
-  if (!result) {
-    console.error("This channel can't send msg");
-    return;
-  }
-  reactionRoleMessage = result;
+  await runSafely("Reaction role message check", async () => {
+    const result = await checkReactionRoleMessage(client);
+    if (!result) {
+      console.error("This channel can't send msg");
+      return;
+    }
+    reactionRoleMessage = result;
+  });
 
-  return client.user?.setActivity("with Discord.js", { type: 0 });
+  await runSafely("Setting bot activity", async () => {
+    client.user?.setActivity("with Discord.js", { type: 0 });
+  });
 });
 
 function logAndSendError(interaction: any, message: string, err?: any) {
@@ -203,17 +225,17 @@ client.on("guildMemberAdd", async (member) => {
 
   if (member.user.bot) {
     // BOTロールを付与
-    member.roles.add("1454099602641780737");
+    await addRoleSafely(member, "1454099602641780737", "bot");
 
     // 学生ロールを付与
-    member.roles.add("1454099602641780737");
+    await addRoleSafely(member, "1454099602641780737", "student");
   }
 
   // 年に応じたロールを付与
   if (date.getFullYear() == 2025) {
-    member.roles.add("1454661774576980090");
+    await addRoleSafely(member, "1454661774576980090", "2025 student");
   } else if (date.getFullYear() == 2026) {
-    member.roles.add("1455864840630308925");
+    await addRoleSafely(member, "1455864840630308925", "2026 student");
   }
 });
 
@@ -225,7 +247,9 @@ client.on("guildMemberRemove", async (member) => {
 client.on("threadCreate", async (thread, newlyCreated) => {
   if (thread.parentId === "1454093291325886658") {
     console.log("[noticeNewRecruit] Detect new Recruit");
-    noticeNewRecruit(client, thread);
+    await runSafely("Notice new recruit thread", () =>
+      noticeNewRecruit(client, thread),
+    );
   }
 });
 
@@ -297,4 +321,6 @@ client.on("messageReactionRemove", async (reaction, user) => {
 });
 
 export { FILE_TYPE, client, commands, actions };
-client.login(process.env.DISCORD_TOKEN);
+client.login(process.env.DISCORD_TOKEN).catch((error) => {
+  console.error("[ERROR] Failed to login Discord client:", error);
+});

--- a/src/jobs/checkReactionRoleMessage.ts
+++ b/src/jobs/checkReactionRoleMessage.ts
@@ -1,8 +1,5 @@
 import { Client } from "discord.js";
 
-const reactionRoleChannelID = process.env["REACTIONROLE_CHANNEL_ID"]!;
-const botID = process.env["BOT_ID"]!;
-
 const REACTION_ROLE_MESSAGE = [
   "リアクションしてロールを付与しよう！",
   ":bell: : 通知勢 : たくさん通知が届くよ！",
@@ -12,6 +9,14 @@ const REACTION_ROLE_MESSAGE = [
 export default async function checkReactionRoleMessage(
   client: Client,
 ): Promise<string | null> {
+  const reactionRoleChannelID = process.env["REACTIONROLE_CHANNEL_ID"];
+  const botID = process.env["BOT_ID"];
+
+  if (!reactionRoleChannelID || !botID) {
+    console.error("REACTIONROLE_CHANNEL_ID or BOT_ID is not set");
+    return null;
+  }
+
   const channel = await client.channels.fetch(reactionRoleChannelID);
 
   if (channel && channel.isTextBased()) {

--- a/src/jobs/noticeNewRecruit.ts
+++ b/src/jobs/noticeNewRecruit.ts
@@ -1,5 +1,13 @@
 import { Client, EmbedBuilder, ThreadChannel } from "discord.js";
 
+async function sendSafely(target: { send: (payload: any) => Promise<unknown> }, payload: any, label: string) {
+  try {
+    await target.send(payload);
+  } catch (error) {
+    console.error(`[noticeNewRecruit] Failed to send ${label}:`, error);
+  }
+}
+
 export default async function noticeNewRecruit(
   client: Client,
   thread: ThreadChannel,
@@ -36,18 +44,18 @@ export default async function noticeNewRecruit(
       .setTimestamp()
       .setColor("#52f525");
 
-    await channel.send({ embeds: [embed] });
+    await sendSafely(channel, { embeds: [embed] }, "recruit notice");
     console.log("[noticeNewRecruit] Successfly sent");
   } catch (error) {
     const embed = new EmbedBuilder()
       .setTitle("エラーが発生しました")
       .setTimestamp()
       .setColor("#ff0000");
-    await thread.send({ embeds: [embed] });
+    await sendSafely(thread, { embeds: [embed] }, "thread error notice");
 
     console.error(error);
 
-    await channel.send({ embeds: [embed] });
+    await sendSafely(channel, { embeds: [embed] }, "channel error notice");
     console.log("[noticeNewRecruit] Successfly sent");
   }
 }


### PR DESCRIPTION
## 概要

起動時ジョブやイベント処理で外部要因のエラーが起きたときに、未処理の Promise rejection として漏れにくいようにしました。

今回のVC削除エラーと同じく、Discord側の権限不足、チャンネル削除済み、環境変数未設定などでBot全体が落ちる可能性がある箇所を保護しています。

## 原因

- `clientReady` 内で `commands.set`、メンバー取得、人数更新、リアクションロールメッセージ確認をそのまま `await` しており、どれか1つが失敗すると起動処理中に例外が漏れる可能性がありました。
- `guildMemberAdd` で `member.roles.add(...)` を `await` していなかったため、ロール管理権限不足やロール順位不足のときに未処理 rejection になる可能性がありました。
- `threadCreate` で `noticeNewRecruit(...)` を `await` / `catch` しておらず、通知送信失敗がイベント処理外に漏れる可能性がありました。
- `checkReactionRoleMessage` が環境変数をimport時に読んでいたため、`.env` の読み込み順によっては未設定扱いになる可能性がありました。

## 変更内容

- `runSafely` を追加し、起動時ジョブやスレッド通知処理の失敗をログに残して握るようにしました。
- `addRoleSafely` を追加し、メンバー参加時のロール付与失敗を個別にログ出力するようにしました。
- `client.login(...)` に `catch` を追加し、トークン未設定や無効トークン時の失敗をログに残すようにしました。
- `checkReactionRoleMessage` の環境変数参照を実行時に移し、未設定時は `null` を返して起動処理を継続できるようにしました。
- `noticeNewRecruit` の通知送信を安全化し、エラー通知そのものが失敗しても例外が漏れないようにしました。

## 確認

- `npm run build` が成功することを確認しました。
- なお、このリポジトリでは既存の `package.json` と `package-lock.json` が同期していないため、`npm ci` は今回の変更前から失敗します。
