### PR TITLE
fix: docker-compose.ymlを新しい基準に適用

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   nanase-bot:
     container_name: nanase-bot


### PR DESCRIPTION
# About this PR
このプルリクエストでは、バージョンが更新されることによる変更により、docker-compose.ymlの先頭のバージョン宣言が不要になったため修正しています。