### PR TITLE
WEBHOOK_URL の環境変数サンプルを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ BOT_ID=bot_id
 REACTIONROLE_CHANNEL_ID=reactionrole_channel_id
 NOTIFIER_ROLE_ID=notifier_role_id
 VC_ROLE_ID=VC_role_id
-
+WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_id/your_webhook_token


### PR DESCRIPTION
## 概要

`.env.example` に `WEBHOOK_URL` のサンプル値を追加しました。

## 背景

VC削除失敗時の通知処理では `process.env.WEBHOOK_URL` を参照していますが、サンプル環境変数に記載がありませんでした。
そのため、通知機能を使う場合にどの環境変数を設定すればよいか分かりにくい状態でした。

## 変更内容

- `.env.example` に `WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_id/your_webhook_token` を追加しました。

## 確認

- `npm run build` が成功することを確認しました。
